### PR TITLE
Implement thread pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,7 @@ dependencies = [
  "scraper",
  "serde",
  "serde_yaml",
+ "threadpool",
 ]
 
 [[package]]
@@ -499,9 +500,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "mime"
@@ -1134,6 +1135,15 @@ name = "thin-slice"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
 
 [[package]]
 name = "tinyvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ reqwest = { version = "0.11.3", features = ["blocking", "json"] }
 scraper = "0.12.0"
 serde = "1.0.125"
 serde_yaml = "0.8.17"
+threadpool = "1.8.1"


### PR DESCRIPTION
These changes allow each actuator to be processed inside of a worker that is part of a larger thread pool. In the future, it might be worth looking into making `merge_tables` implement a similar system, although the performance improvement may not be as significant.

Resolves #2 